### PR TITLE
[NEW] HF Sync plugin

### DIFF
--- a/argilla_plugins/datasets/__init__.py
+++ b/argilla_plugins/datasets/__init__.py
@@ -1,4 +1,5 @@
 from argilla_plugins.datasets.end_of_life import end_of_life
 from argilla_plugins.datasets.remove_duplicate import remove_duplicate
+from argilla_plugins.datasets.hf_sync import hf_sync, HuggingfaceSyncConfig
 
-__all__ = ["end_of_life", "remove_duplicate"]
+__all__ = ["end_of_life", "remove_duplicate", "hf_sync", "HuggingfaceSyncConfig"]

--- a/argilla_plugins/datasets/hf_sync.py
+++ b/argilla_plugins/datasets/hf_sync.py
@@ -1,0 +1,185 @@
+import dataclasses
+import os
+import time
+from threading import Thread
+from typing import Optional, Set
+
+from datasets import Dataset, load_dataset
+
+import argilla as rg
+from argilla.client.sdk.commons.errors import NotFoundApiError
+from argilla.server.commons.models import TaskType
+
+
+@dataclasses.dataclass
+class Config:
+
+    hf_source: Optional[str] = None
+    hf_target: Optional[str] = None
+    hf_token: Optional[str] = None
+    hf_split: str = "train"
+    hf_push_to_hub_frequency: int = 60
+
+    rg_task: TaskType = TaskType.text_classification
+    rg_dataset: Optional[str] = None
+    rg_query: Optional[str] = None
+    rg_labels: Optional[Set[str]] = None
+    rg_multi_label_dataset: Optional[bool] = None
+    rg_log_batch_size: int = 200
+    rg_load_batch_size: int = 200
+
+    def __post_init__(self):
+
+        if not (self.hf_source or self.hf_target or self.rg_dataset):
+            raise ValueError("Must specify a source/target dataset or an rg_dataset")
+
+        if not self.rg_dataset:
+            dataset_name = self.hf_target or self.hf_source
+            self.rg_dataset = dataset_name.split("/")[-1]
+
+        if not self.hf_target:
+            self.hf_target = self.hf_source or self.rg_dataset  # must provide an org????
+
+        self.hf_token = self.hf_token or os.environ.get("HF_TOKEN")
+
+
+class HuggingfaceSync(Thread):
+    def __init__(self, config: Config, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._config = config
+        self.stop = False
+
+    def run(self) -> None:
+
+        self.import_data()
+
+        while not self.stop:
+            time.sleep(self._config.hf_push_to_hub_frequency)
+            self.export_data()
+
+    def import_data(self):
+        """Import data from HF hub to Argilla"""
+
+        if not self._exist_argilla_dataset():
+            hf_dataset = self._load_dataset_safety(self._config.hf_source, split=self._config.hf_split)
+
+            if not hf_dataset:
+                return
+
+            self._log_hf_dataset(hf_dataset)
+
+        if self._config.hf_source != self._config.hf_target or self._exist_argilla_dataset():
+
+            target_ds = self._load_dataset_safety(self._config.hf_target, split=self._config.hf_split)
+
+            if not target_ds:
+                return
+
+            self._log_hf_dataset(target_ds)
+
+    def export_data(self):
+        """Export data from Argilla to HF hub"""
+        if not self._config.hf_token:
+            return
+
+        rg_dataset = rg.load(
+            self._config.rg_dataset,
+            query=self._config.rg_query,
+            batch_size=self._config.rg_load_batch_size,
+        )
+
+        if not rg_dataset:
+            return
+
+        hf_dataset = rg_dataset.to_datasets()
+        hf_dataset.push_to_hub(self._config.hf_target, token=self._config.hf_token, split=self._config.hf_split)
+
+    def _log_hf_dataset(self, dataset: Dataset):
+
+        task = self._config.rg_task
+        if task == TaskType.text_classification:
+            ds_class = rg.DatasetForTextClassification
+        elif task == TaskType.token_classification:
+            ds_class = rg.DatasetForTokenClassification
+        elif task == TaskType.text2text:
+            ds_class = rg.DatasetForText2Text
+        else:
+            raise RuntimeError(f"Wrong task {task}")
+
+        records = ds_class.from_datasets(dataset)
+
+        if ds_class == rg.DatasetForTextClassification and self._config.rg_multi_label_dataset:
+            for record in records:
+                record.multi_label = True
+
+        self._prepare_dataset()
+        rg.log(records, name=self._config.rg_dataset, batch_size=self._config.rg_log_batch_size)
+
+    def _exist_argilla_dataset(self):
+
+        try:
+            rg.load(name=self._config.rg_dataset, limit=1)
+            return True
+        except NotFoundApiError:
+            return False
+
+    def _load_dataset_safety(self, dataset: str, split: str) -> Optional[Dataset]:
+        try:
+            return load_dataset(dataset, split=split, use_auth_token=self._config.hf_token)
+        except:
+            return None
+
+    def _prepare_dataset(self):
+        task = self._config.rg_task
+        labels = self._config.rg_labels
+
+        if not task in [TaskType.text_classification, TaskType.token_classification]:
+            return
+
+        if not labels:
+            return
+
+        if task == TaskType.text_classification:
+            settings_cls = rg.TextClassificationSettings
+        else:
+            settings_cls = rg.TokenClassificationSettings
+
+        rg.configure_dataset(name=self._config.rg_dataset, settings=settings_cls(label_schema=labels))
+
+
+def hf_sync(
+    hf_source: Optional[str] = None,
+    hf_target: Optional[str] = None,
+    hf_token: Optional[str] = None,
+    hf_split: str = "train",
+    hf_push_to_hub_frequency: int = 60,
+
+    rg_task: TaskType = TaskType.text_classification,
+    rg_dataset: Optional[str] = None,
+    rg_query: Optional[str] = None,
+    rg_labels: Optional[Set[str]] = None,
+    rg_multi_label_dataset: Optional[bool] = None,
+    rg_log_batch_size: int = 200,
+    rg_load_batch_size: int = 200,
+):
+    """Syncs an Argilla dataset with a dataset in HF"""
+
+    config = Config(
+        hf_source=hf_source,
+        hf_target=hf_target,
+        hf_token=hf_token,
+        hf_split=hf_split,
+        hf_push_to_hub_frequency=hf_push_to_hub_frequency,
+
+        rg_task=rg_task,
+        rg_dataset=rg_dataset,
+        rg_query=rg_query,
+        rg_labels=rg_labels,
+        rg_multi_label_dataset=rg_multi_label_dataset,
+        rg_log_batch_size=rg_log_batch_size,
+        rg_load_batch_size=rg_load_batch_size,
+    )
+
+    plugin = HuggingfaceSync(config)
+
+    return plugin

--- a/argilla_plugins/datasets/hf_sync.py
+++ b/argilla_plugins/datasets/hf_sync.py
@@ -171,8 +171,8 @@ class HuggingfaceSync(Thread):
         rg.configure_dataset(name=self._config.rg_dataset, settings=settings_cls(label_schema=labels))
 
 
-def hf_sync(config: HuggingfaceSyncConfig):
+def hf_sync(config: Optional[HuggingfaceSyncConfig] = None):
     """Syncs an Argilla dataset with a dataset in HF"""
 
-    plugin = HuggingfaceSync(config)
+    plugin = HuggingfaceSync(config or HuggingfaceSyncConfig())
     return plugin


### PR DESCRIPTION
With this plugin, users can sync data from/to the HF datasets hub and an Argilla instance.

Refs https://github.com/argilla-io/argilla/issues/2614  

## Description

Since this plugin has several optional configurations, can cover several use cases. Let's enumerate some of them

1. Automatically import an HF dataset into your Argilla instance (by setting the `hf_source`)
2. Export total or partial dataset records into an HF dataset (by setting the `hf_target` and `rg_dataset` parameters)
3. Sync HF datasets with changes from Argilla (by setting the `hf_source=hf_target` and `rg_query=None`). Be careful with this since the dataset will be exported totally each `hf_push_to_hub_frequency` seconds.

